### PR TITLE
墓地リンクからの画面遷移

### DIFF
--- a/src/main/resources/templates/game.html
+++ b/src/main/resources/templates/game.html
@@ -16,14 +16,12 @@
   <div th:if="${uranai}">
     <img src='seer.JPG' width="200px" height="200px" alt="占い師" />
     <h3>占い対象</h3>
-    <div th:each="uranai:${uranai}">
-      <ul>
+    <ul>
+      <div th:each="uranai:${uranai}">
         <li><a th:href="@{/uranai(target=${uranai.username})}">[[${uranai.username}]]</a></li>
-      </ul>
-      <ul>
-        <li><a th:href="@{/uranai(target=graveyard)}">墓地</a></li>
-      </ul>
-    </div>
+      </div>
+      <li><a th:href="@{/uranai(target=graveyard)}">墓地</a></li>
+    </ul>
   </div>
   <div th:if="${predictTarget}">
     <h3>占い結果</h3>
@@ -31,7 +29,10 @@
   </div>
   <div th:if="${graveyard}">
     <h3>占い結果</h3>
-    <p>墓地の役職は[[${graveyard[0].name}]]と[[${graveyard[1].name}]]です</p>
+    <p>墓地の役職は以下の通りです</p>
+    <div th:each="graveyard:${graveyard}">
+      <p>[[${graveyard.name}]]</p>
+    </div>
   </div>
   <div th:if="${kaito}">
     <img src='thief.JPG' width="200px" height="200px" alt="怪盗" />
@@ -50,7 +51,7 @@
     <img src='villager.JPG' width="200px" height="200px" alt="市民" />
   </div>
   <div>
-  <a href="/entry" class="button">もどる</a>
+    <a href="/entry" class="button">もどる</a>
   </div>
 
 </body>


### PR DESCRIPTION
占い師が役職が「占い師」の時、占い対象に墓地が複数箇所あったのでそれを1箇所のみ表示させるようにした。また、そのリンクに正常に遷移するようにした。