### PR TITLE
logout機能の修正

### DIFF
--- a/src/main/java/team5/game/security/ZinrouAuthConfiguration.java
+++ b/src/main/java/team5/game/security/ZinrouAuthConfiguration.java
@@ -32,8 +32,8 @@ public class ZinrouAuthConfiguration {
             .loginProcessingUrl("/login") // ログイン処理を受け付けるURLを指定
             .permitAll())
         .logout(logout -> logout
-            .logoutUrl("/logout")
-            .logoutSuccessUrl("/")); // ログアウト後に / にリダイレクト
+            .logoutRequestMatcher(new AntPathRequestMatcher("/logout"))
+            .logoutSuccessUrl("/"));
 
     return http.build();
   }


### PR DESCRIPTION

## 修正内容

* localhost:8080/logout にアクセスするとエラーが出ていたので， localhost:8080/entry のログアウトボタンを押すとlocalhost:8080 にリダイレクトをし，エラーが出ないように修正した．

## やったこと

* [ ] localhost:8080/entry のログアウトボタンを押すと localhost:8080 にリダイレクトする.
* [ ] ログアウトの後にlocalhost:8080/entry にアクセスしても localhost:8080 にリダイレクトし，再びuserとpassが聞かれる．