### PR TITLE
投票画面までの自動遷移の実装とデバック用のボタンの削除

### DIFF
--- a/src/main/java/team5/game/controller/JinroController.java
+++ b/src/main/java/team5/game/controller/JinroController.java
@@ -21,6 +21,8 @@ import team5.game.service.AsyncStandbyRoom;
 import team5.game.service.AsyncCheck;
 import team5.game.service.AsyncKaigi;
 import team5.game.service.AsyncToRoles;
+import team5.game.service.AsyncVote;
+import team5.game.service.AsyncVotePhase;
 
 @Controller
 @SessionAttributes("userinfo")
@@ -46,6 +48,12 @@ public class JinroController {
 
   @Autowired
   private AsyncToRoles asyncToRoles;
+
+  @Autowired
+  private AsyncVote asyncVote;
+
+  @Autowired
+  private AsyncVotePhase asyncVotePhase;
 
   @GetMapping("/entry")
   public String entry() {
@@ -158,5 +166,26 @@ public class JinroController {
     final SseEmitter emitter = new SseEmitter();
     this.asyncToRoles.toRoles(emitter);
     return emitter;
-  } 
+  }
+
+  @GetMapping("/toVote")
+  public SseEmitter toVote() {
+    final SseEmitter emitter = new SseEmitter();
+    this.asyncVote.vote(emitter);
+    return emitter;
+  }
+
+  @GetMapping("/votePhase")
+  public SseEmitter votePhase() {
+    final SseEmitter emitter = new SseEmitter();
+    this.asyncVotePhase.votePhase(emitter);
+    return emitter;
+  }
+
+  @GetMapping("/vote")
+  public String vote(Principal prin, ModelMap model) {
+    Userinfo userinfo = userinfoMapper.selectUserinfo(prin.getName());
+    model.addAttribute("userinfo", userinfo);
+    return "vote";
+  }
 }

--- a/src/main/java/team5/game/service/AsyncVote.java
+++ b/src/main/java/team5/game/service/AsyncVote.java
@@ -1,0 +1,44 @@
+package team5.game.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import ch.qos.logback.classic.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.TimeUnit;
+import java.util.ArrayList;
+import team5.game.model.UserinfoMapper;
+
+@Service
+public class AsyncVote {
+
+  private boolean max = false;
+
+  private final Logger logger = (Logger) LoggerFactory.getLogger(this.getClass());
+
+  @Autowired
+  private UserinfoMapper userinfoMapper;
+
+  @Async
+  public void vote(SseEmitter emitter) {
+    try {
+      while (true) {
+        ArrayList<String> joinUserList = userinfoMapper.selectNotnullUses();
+        emitter.send(joinUserList);
+        logger.info("joinUserList:" + joinUserList);
+        TimeUnit.MILLISECONDS.sleep(500);
+        if (joinUserList.size() == 4) {
+          max = true;
+          break;
+        }
+      }
+    } catch (Exception e) {
+      logger.warn("Exception:" + e.getClass().getName() + ":" + e.getMessage());
+    } finally {
+      emitter.complete();
+    }
+  }
+}

--- a/src/main/java/team5/game/service/AsyncVotePhase.java
+++ b/src/main/java/team5/game/service/AsyncVotePhase.java
@@ -1,0 +1,44 @@
+package team5.game.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import ch.qos.logback.classic.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.TimeUnit;
+import java.util.ArrayList;
+import team5.game.model.UserinfoMapper;
+
+@Service
+public class AsyncVotePhase {
+
+  private boolean max = false;
+
+  private final Logger logger = (Logger) LoggerFactory.getLogger(this.getClass());
+
+  @Autowired
+  private UserinfoMapper userinfoMapper;
+
+  @Async
+  public void votePhase(SseEmitter emitter) {
+    try {
+      while (true) {
+        ArrayList<String> joinUserList = userinfoMapper.selectNotnullUses();
+        emitter.send(joinUserList);
+        logger.info("joinUserList:" + joinUserList);
+        TimeUnit.MILLISECONDS.sleep(100000);
+        if (joinUserList.size() == 4) {
+          max = true;
+          break;
+        }
+      }
+    } catch (Exception e) {
+      logger.warn("Exception:" + e.getClass().getName() + ":" + e.getMessage());
+    } finally {
+      emitter.complete();
+    }
+  }
+}

--- a/src/main/resources/templates/entry.html
+++ b/src/main/resources/templates/entry.html
@@ -14,9 +14,6 @@
     <p>
       <a href="/standby" class="button">スタート</a>
     </p>
-    <p th:if="${userinfo}">
-      <a href="/game" class="button">コンテニュー</a>
-    </p>
     <p>
       <a href="/rules" class="button">ルール</a>
     </p>

--- a/src/main/resources/templates/kaigi.html
+++ b/src/main/resources/templates/kaigi.html
@@ -5,6 +5,18 @@
   <meta charset="utf-8">
   <title>人狼ゲーム-昼のターン</title>
   <link rel="stylesheet" href="style_k.css">
+  <script>
+    window.onload = function () {
+      var sse = new EventSource('/toVote');
+      sse.onmessage = function (event) {
+        console.log(event.data);
+        // 5秒後に自動遷移する（5000ミリ秒 = 5秒）
+        setTimeout(function () {
+          window.location.href = "/vote"; // リダイレクト先のURL
+        }, 5000);
+      }
+    }
+  </script>
 </head>
 
 <body>

--- a/src/main/resources/templates/standby.html
+++ b/src/main/resources/templates/standby.html
@@ -42,9 +42,6 @@
         <tobody id="userList"></tobody>
       </div>
       <br /><br />
-      <div>
-        <a href="/entry" class="button">もどる</a>
-      </div>
     </div>
   </div>
 

--- a/src/main/resources/templates/vote.html
+++ b/src/main/resources/templates/vote.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="utf-8">
+  <title>人狼ゲーム-投票タイム</title>
+  <link rel="stylesheet" href="style_k.css">
+  <script>
+    window.onload = function () {
+      var sse = new EventSource('/votePhase');
+      sse.onmessage = function (event) {
+        console.log("sse.onmessage");
+        console.log(event.data);
+        var userList = JSON.parse(event.data);
+        var usertable = "";
+        usertable += "<ul>";
+        for (var i = 0; i < userList.length; i++) {
+          usertable += '<input type="radio" name="vote" value="' + userList[i] + '">';
+          usertable += '<label>' + userList[i] + '</label><br>';
+        }
+        usertable += "</ul>";
+        usertable += "<br/>";
+        console.log(usertable);
+        var tobody = document.getElementById("userList");
+        tobody.innerHTML = usertable;
+      }
+    }
+  </script>
+</head>
+
+<body>
+  <div class="backgraund">
+    <div id="explanation">
+      <h2>投票タイム</h2>
+      <p>吊りたいと思った人物または吊らないのボタンを押してください</p>
+      <div>
+        <tobody id="userList"></tobody>
+      </div>
+      <br /><br />
+    </div>
+  </div>
+</body>
+
+</html>


### PR DESCRIPTION
＜実装内容＞
kaigi画面まで遷移した後さらに5秒後にvote画面(投票画面)が自動遷移し表示される。
vote画面では「投票タイム」「吊りたいと思った人物または吊らないのボタンを押してください」「ユーザ名」の順で縦に並んでおり、ユーザ名はラジオボタン形式で押すことにより選択することができる。

＜修正内容＞
デバック用で用意していたルール説明画面以外の「もどる」ボタンとentry画面での「コンテニュー」ボタンの消去

＜課題点＞
ラジオボタン形式で押すことにより選択したデータを維持して次の画面である結果画面に渡せるようにする。
自動遷移の時間を本番に近い形で設定するようにする。