### PR TITLE
会議時にチャット機能

### DIFF
--- a/src/main/java/team5/game/controller/BulletinBoardApiController.java
+++ b/src/main/java/team5/game/controller/BulletinBoardApiController.java
@@ -12,7 +12,7 @@ public class BulletinBoardApiController {
   @Autowired
   private BulletinBoardService bulletinBoardService;
 
-  @GetMapping("/api/messages")
+  @GetMapping("/api/kaigi")
   public List<String> getMessages() {
     return bulletinBoardService.getAllMessages();
   }

--- a/src/main/java/team5/game/controller/BulletinBoardController.java
+++ b/src/main/java/team5/game/controller/BulletinBoardController.java
@@ -16,15 +16,15 @@ public class BulletinBoardController {
   @Autowired
   private BulletinBoardService bulletinBoardService;
 
-  @GetMapping("/messages")
+  @GetMapping("/kaigi")
   public String getAllMessages(Model model) {
-    model.addAttribute("messages", bulletinBoardService.getAllMessages());
-    return "messages";
+    model.addAttribute("kaigi", bulletinBoardService.getAllMessages());
+    return "kaigi";
   }
 
   @PostMapping("/post")
   public String postMessage(@RequestParam("message") String message) {
     bulletinBoardService.postMessage(message);
-    return "redirect:/messages";
+    return "redirect:/kaigi";
   }
 }

--- a/src/main/java/team5/game/controller/JinroController.java
+++ b/src/main/java/team5/game/controller/JinroController.java
@@ -149,11 +149,6 @@ public class JinroController {
     return "check";
   }
 
-  @GetMapping("/kaigi")
-  public String kaigi() {
-    return "kaigi";
-  }
-
   @GetMapping("/movekaigi")
   public SseEmitter movekaigi() {
     final SseEmitter emitter = new SseEmitter();

--- a/src/main/resources/templates/kaigi.html
+++ b/src/main/resources/templates/kaigi.html
@@ -6,7 +6,8 @@
   <title>人狼ゲーム-昼のターン</title>
   <link rel="stylesheet" href="style_k.css">
   <script>
-    var seconds = 180;
+    var seconds = getRemainingTime();
+
     window.onload = function () {
       var countdownDisplay = document.getElementById('countdown');
 
@@ -14,7 +15,6 @@
         var minutes = Math.floor(seconds / 60);
         var remainingSeconds = seconds % 60;
 
-        // 1桁の場合、0を前に付ける
         if (remainingSeconds < 10) {
           remainingSeconds = "0" + remainingSeconds;
         }
@@ -25,14 +25,42 @@
           clearInterval(countdownInterval);
           if (seconds == 0) {
             alert("投票タイムに進みます");
-            window.location.href = "/vote"; // カウントダウン終了後のリダイレクト先のURL
+            window.location.href = "/vote";
           }
         } else {
           seconds--;
+          setRemainingTime(seconds);
         }
-      }, 1000); // 1秒ごとにカウントダウン
+      }, 1000);
+    }
+
+    function getRemainingTime() {
+      var remainingTime = localStorage.getItem('remainingTime');
+      return remainingTime !== null ? parseInt(remainingTime) : 180; // デフォルトは3分
+    }
+
+    function setRemainingTime(time) {
+      localStorage.setItem('remainingTime', time);
     }
   </script>
+
+  <script src="https://code.jquery.com/jquery-3.6.4.min.js"></script>
+  <script th:inline="javascript">
+    $(document).ready(function () {
+      function updateMessages() {
+        $.get("/api/kaigi", function (data) {
+          var messageList = $("#message-list");
+          messageList.empty();
+          $.each(data, function (index, message) {
+            messageList.append("<li>" + message + "</li>");
+          });
+        });
+      }
+
+      setInterval(updateMessages, 3000);
+    });
+  </script>
+
 </head>
 
 <body>
@@ -42,6 +70,15 @@
       <p>3分間話し合いを行ってください</p>
     </div>
     <h2 id="countdown">3:00</h2>
+
+    <ul id="message-list">
+      <li th:each="message : ${kaigi}" th:text="${message}"></li>
+    </ul>
+
+    <form th:action="@{/post}" method="post" id="post-form">
+      <input type="text" name="message" placeholder="Type your message" required />
+      <button type="submit">Post</button>
+    </form>
   </div>
 </body>
 


### PR DESCRIPTION
## 変更内容

* localhost:8080/kaigi にチャット機能を追加
* チャットに文字を打ってpostを打つとリダイレクトされ，時間が3:00に戻ってしまっていたため，リダイレクト前に経過時間を保持することで，チャットを打ってもカウントダウンの秒数が保たれている．

## やったこと

* [ ] localhost:8080/kaigi にアクセスするとメッセージボックスとpostボタンがあり，メッセージをpostすると下に投稿文字が表示される．
* [ ] 別のアカウントでlocalhost:8080/kaigi にアクセスし，先ほど打ったメッセージが表示されており，こちらからチャットを打つと先ほどのアカウントでもチャット内容が下に表示される(非同期)．

## 課題

* localhost:8080/kaigi でメッセージを打った後に，postを押すとリダイレクトされるため，一瞬リロードが入る．
* ログインしたユーザー名が投稿した文字の左側にコロン越しに表示されるようにする．例「usre1:こんにちは」
