### PR TITLE
ゲーム結果処理と表示の実装

### DIFF
--- a/src/main/java/team5/game/model/RolesMapper.java
+++ b/src/main/java/team5/game/model/RolesMapper.java
@@ -14,7 +14,10 @@ public interface RolesMapper {
   @Select("SELECT * FROM roles WHERE use = false")
   ArrayList<Roles> selectGraveyard();
 
-  @Update("UPDATE roles SET use = #{true} WHERE id = #{id}")
+  @Update("UPDATE roles SET use = true WHERE id = #{id}")
   void updateUserInfo(int id);
+
+  @Update("UPDATE roles SET use = false")
+  void updateUserInfoNull();
 
 }

--- a/src/main/java/team5/game/service/AsyncVoteFinish.java
+++ b/src/main/java/team5/game/service/AsyncVoteFinish.java
@@ -1,0 +1,41 @@
+package team5.game.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import ch.qos.logback.classic.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.TimeUnit;
+import java.util.ArrayList;
+import team5.game.model.UserinfoMapper;
+
+@Service
+public class AsyncVoteFinish {
+
+  private final Logger logger = (Logger) LoggerFactory.getLogger(this.getClass());
+
+  @Autowired
+  private UserinfoMapper userinfoMapper;
+
+  @Async
+  public void voteFinish(SseEmitter emitter) {
+    try {
+      while (true) {
+        ArrayList<String> joinUserList = userinfoMapper.selectTrueSelected();
+        emitter.send(joinUserList);
+        logger.info("joinUserList:" + joinUserList);
+        TimeUnit.MILLISECONDS.sleep(500);
+        if (joinUserList.size() == 4) {
+          break;
+        }
+      }
+    } catch (Exception e) {
+      logger.warn("Exception:" + e.getClass().getName() + ":" + e.getMessage());
+    } finally {
+      emitter.complete();
+    }
+  }
+}

--- a/src/main/resources/templates/gameresult.html
+++ b/src/main/resources/templates/gameresult.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="utf-8">
+  <title>人狼ゲーム-結果</title>
+</head>
+
+<body>
+  <h1>結果</h1>
+  <p>[[${result}]]</p>
+  <p><a href=/resume class="button">もどる</a></p>
+</body>
+
+</html>

--- a/src/main/resources/templates/voteresult.html
+++ b/src/main/resources/templates/voteresult.html
@@ -4,6 +4,30 @@
 <head>
   <meta charset="utf-8">
   <title>人狼ゲーム-投票結果</title>
+  <script>
+    var selection = "[[${selection}]]";
+    window.onload = function () {
+      var sse = new EventSource('/voteFinish');
+      sse.onmessage = function (event) {
+        console.log("sse.onmessage");
+        console.log(event.data);
+        var userList = JSON.parse(event.data);
+        var usertable = "";
+        usertable += "<ul>";
+        usertable += "</ul>";
+        usertable += "<br/>";
+        if (userList.length == 4) {
+          usertable += "<p>4人のユーザが集まったので結果へ進みます</p>";
+          setTimeout(function () {
+            window.location.href = "/gameresult?selection=" + selection; // リダイレクト先のURL
+          }, 5000);
+        }
+        console.log(usertable);
+        var tobody = document.getElementById("userList");
+        tobody.innerHTML = usertable;
+      }
+    }
+  </script>
 </head>
 
 <body>
@@ -14,6 +38,10 @@
   <p>user2:[[${count_2}]]票</p>
   <p>user3:[[${count_3}]]票</p>
   <p>user4:[[${count_4}]]票</p>
+  <div>
+    <tobody id="userList"></tobody>
+  </div>
+  <br /><br />
 </body>
 
 </html>


### PR DESCRIPTION
投票結果画面が表示された5秒後に投票されたプレイヤーの役職によってゲーム結果を処理してゲーム結果画面として表示する。
(ex.投票で選択された人物の役職が人狼の場合は、「市民側の勝利」と表示される)
その下にentry画面に戻るリンク付きの「もどる」も表示
そのタイミングで役職テーブルのuseをnullにしたりなどリセットを行っている。
h2-console上では初期値にリセットされている。

<課題点>
2回目のゲームをスタートができない。(ユーザ2人しかstandbyroomに遷移できない)
・恐らく役職が重複しないようにしたところが残ってしまっているのか
・ローカルストレージのような内部的なデータが影響しているのか
の2点が原因として考えている。